### PR TITLE
Add avoid_void_async

### DIFF
--- a/lib/bloom.yaml
+++ b/lib/bloom.yaml
@@ -46,6 +46,7 @@ linter:
     - avoid_catching_errors
     - use_rethrow_when_possible
     - prefer_final_locals
+    - avoid_void_async
   
     # DESIGN
     - prefer_single_quotes


### PR DESCRIPTION
Ik wil graag deze linter rule toevoegen [avoid_void_async](https://dart.dev/tools/linter-rules/avoid_void_async) aangezien ik als beginnende flutter dev hier de fout inging.

Met deze rule is het niet meer mogelijk om een void return type te hebben voor een async functie. Elke keer als iemand mij tijdens een code review op fouten attendeert die kunnen worden afgevangen door linter regels, zou ik deze graag toevoegen.